### PR TITLE
fix: Closes #4 修复评论发布时之前的评论被移出列表的问题

### DIFF
--- a/web/src/components/comment/index.tsx
+++ b/web/src/components/comment/index.tsx
@@ -71,7 +71,6 @@ export function CommentSection(
     }).then(res => {
       toast.success(t("comment_success"));
       setTotalCommentCount(c => c + 1);
-      setComments(prevComments => prevComments.slice(0, -1));
       getComment({ id: res.data.id }).then(response => {
         console.log("New comment fetched:", response.data);
         setComments(prevComments => [response.data, ...prevComments]);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Removed the setComments slice call that was erroneously removing previous comments on new comment submission