### PR TITLE
✨ feat(music): 支持外语歌词与播放器状态持久化

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -81,7 +81,8 @@
     "schema-dts": "^1.1.5",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "wanakana": "5.3.1"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^5.4.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      wanakana:
+        specifier: 5.3.1
+        version: 5.3.1
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^5.4.1
@@ -705,105 +708,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -882,28 +869,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -962,42 +945,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -1572,79 +1549,66 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -1722,42 +1686,36 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.40':
     resolution: {integrity: sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.40':
     resolution: {integrity: sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.40':
     resolution: {integrity: sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.40':
     resolution: {integrity: sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.40':
     resolution: {integrity: sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.40':
     resolution: {integrity: sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==}
@@ -1841,28 +1799,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -2290,61 +2244,51 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -3641,28 +3585,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4752,6 +4692,10 @@ packages:
 
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+  wanakana@5.3.1:
+    resolution: {integrity: sha512-OSDqupzTlzl2LGyqTdhcXcl6ezMiFhcUwLBP8YKaBIbMYW1wAwDvupw2T9G9oVaKT9RmaSpyTXjxddFPUcFFIw==}
+    engines: {node: '>=12'}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -9515,6 +9459,8 @@ snapshots:
       - supports-color
 
   w3c-keyname@2.2.8: {}
+
+  wanakana@5.3.1: {}
 
   whatwg-encoding@3.1.1:
     dependencies:

--- a/web/src/components/common/music-lyric-scroll.tsx
+++ b/web/src/components/common/music-lyric-scroll.tsx
@@ -2,14 +2,17 @@ import { useTranslations } from 'next-intl'
 import { useEffect, useRef, useState } from 'react'
 import { useMusic } from '@/contexts/music-context'
 import { cn } from '@/lib/utils'
-import { getCurrentLyricIndex, getWordProgress } from '@/utils/music-lyric'
+import { getCurrentLyricIndex, getExtraLyricLine, getWordProgress } from '@/utils/music-lyric'
 
 export default function LyricScroll() {
   const t = useTranslations('MusicPlayer')
   const {
     lyricLines,
     parsedLyricLines,
+    translationLyricLines,
+    romajiLyricLines,
     lyricSourceType,
+    lyricMode,
     currentLyricIndex,
     currentTime,
     getAudio,
@@ -74,6 +77,15 @@ export default function LyricScroll() {
         const offset = idx - activeLyricIndex
         const isCurrent = idx === activeLyricIndex
         const isWordLyric = lyricSourceType === 'yrc' && line.items.some(item => item.duration > 0)
+        const extraLyricLines = lyricMode === 'translation'
+          ? translationLyricLines
+          : lyricMode === 'romaji'
+            ? romajiLyricLines
+            : []
+        const extraLine = extraLyricLines.length > 0
+          ? getExtraLyricLine(extraLyricLines, line.startTime)
+          : null
+        const isTimedExtraLine = Boolean(extraLine?.items.some(item => item.duration > 0))
 
         return (
           <div
@@ -128,6 +140,48 @@ export default function LyricScroll() {
                 </span>
               )
             })}
+            {extraLine && (
+              <div
+                className={cn(
+                  'mt-0.5 text-sm leading-5 font-medium transition-colors',
+                  isCurrent ? 'text-primary/80' : 'text-slate-500 dark:text-slate-500',
+                )}
+              >
+                {extraLine.items.map((item, itemIdx) => {
+                  const itemText = item.text.replace(/\s+$/g, match => '\u00A0'.repeat(match.length))
+                  if (!isTimedExtraLine || !isCurrent) {
+                    return (
+                      <span key={itemIdx}>
+                        {itemText}
+                      </span>
+                    )
+                  }
+
+                  const itemEndTime = item.startTime + item.duration
+                  const isPast = currentTimeMs >= itemEndTime
+                  const isActive = currentTimeMs >= item.startTime && currentTimeMs < itemEndTime
+                  const progress = isPast ? 1 : isActive ? getWordProgress(item, currentTimeMs) : 0
+
+                  return (
+                    <span key={itemIdx} className="inline-block relative align-baseline">
+                      <span className="select-none text-primary/40">{itemText}</span>
+                      {progress > 0 && (
+                        <span
+                          className="absolute inset-0 select-none text-primary/80"
+                          style={{
+                            clipPath: `inset(0 ${(1 - progress) * 100}% 0 0)`,
+                            willChange: 'clip-path',
+                            pointerEvents: 'none',
+                          }}
+                        >
+                          {itemText}
+                        </span>
+                      )}
+                    </span>
+                  )
+                })}
+              </div>
+            )}
           </div>
         )
       })}

--- a/web/src/components/common/music-player.tsx
+++ b/web/src/components/common/music-player.tsx
@@ -2,8 +2,9 @@
 
 import type { PlayMode } from '@/contexts/music-context'
 import type { MusicTrack } from '@/models/music'
+import type { MusicLyricMode } from '@/utils/music-lyric'
 import { useMeasure } from '@uidotdev/usehooks'
-import { CircleArrowLeftIcon, CircleArrowRightIcon, CirclePauseIcon, CirclePlayIcon, ListMusicIcon, MusicIcon, Repeat1Icon, RepeatIcon, SearchIcon, Shuffle } from 'lucide-react'
+import { CaseSensitiveIcon, CircleArrowLeftIcon, CircleArrowRightIcon, CirclePauseIcon, CirclePlayIcon, LanguagesIcon, ListMusicIcon, MessageSquareOffIcon, MusicIcon, Repeat1Icon, RepeatIcon, SearchIcon, Shuffle, Volume2Icon, VolumeXIcon } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import Image from 'next/image'
 import React, { useEffect, useRef, useState } from 'react'
@@ -92,6 +93,11 @@ export function MusicPlayer() {
 
   // 当存储的播放时间加载完成时，seek 到该时间（只执行一次）
   useEffect(() => {
+    if (isStoredTimeLoaded && storedTime == null && !appliedStoredTimeRef.current) {
+      appliedStoredTimeRef.current = true
+      return
+    }
+
     // guard conditions
     if (
       !isStoredTimeLoaded
@@ -405,6 +411,7 @@ function PlayerControls() {
         onIsDraggingChange={setIsDragging}
       />
       <div className="flex items-center justify-center mt-2 gap-4 text-slate-500 ">
+        <MuteButton />
         <PlayModeButton />
         <CircleArrowLeftIcon className={cn('w-6 h-6', BUTTON_ANIMATION_CLASSNAME)} onClick={prev} />
         {isPlaying
@@ -422,8 +429,71 @@ function PlayerControls() {
             )}
         <CircleArrowRightIcon className={cn('w-6 h-6', BUTTON_ANIMATION_CLASSNAME)} onClick={next} />
         <Playlist />
+        <LyricModeButton />
       </div>
     </div>
+  )
+}
+
+function MuteButton() {
+  const { isMuted, toggleMuted } = useMusic()
+  const iconClassName = cn('w-5 h-5', BUTTON_ANIMATION_CLASSNAME)
+
+  return (
+    <button
+      type="button"
+      aria-label={isMuted ? '取消静音' : '静音'}
+      title={isMuted ? '取消静音' : '静音'}
+      onClick={toggleMuted}
+      className={cn('p-1', isMuted ? 'text-primary' : '')}
+    >
+      {isMuted
+        ? <VolumeXIcon className={iconClassName} />
+        : <Volume2Icon className={iconClassName} />}
+    </button>
+  )
+}
+
+function LyricModeButton() {
+  const {
+    lyricMode,
+    setLyricMode,
+    hasRomajiLyric,
+    hasTranslationLyric,
+  } = useMusic()
+  const hasExtraLyric = hasRomajiLyric || hasTranslationLyric
+  const iconClassName = cn('w-5 h-5', hasExtraLyric ? BUTTON_ANIMATION_CLASSNAME : '')
+
+  const getNextMode = (mode: MusicLyricMode): MusicLyricMode => {
+    if (mode === 'none')
+      return 'romaji'
+    if (mode === 'romaji')
+      return 'translation'
+    return 'none'
+  }
+
+  const iconMap: Record<MusicLyricMode, React.ReactNode> = {
+    none: <MessageSquareOffIcon className={iconClassName} />,
+    romaji: <CaseSensitiveIcon className={iconClassName} />,
+    translation: <LanguagesIcon className={iconClassName} />,
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label="切换歌词附加显示"
+      aria-disabled={!hasExtraLyric}
+      title={!hasExtraLyric ? '暂无翻译或罗马音' : lyricMode === 'none' ? '无附加歌词' : lyricMode === 'romaji' ? '罗马音' : '翻译'}
+      onClick={() => setLyricMode(getNextMode(lyricMode))}
+      disabled={!hasExtraLyric}
+      className={cn(
+        'p-1',
+        !hasExtraLyric ? 'cursor-not-allowed text-slate-300 dark:text-slate-600 hover:scale-100 hover:text-slate-300 dark:hover:text-slate-600' : '',
+        hasExtraLyric && lyricMode !== 'none' ? 'text-primary' : '',
+      )}
+    >
+      {iconMap[lyricMode]}
+    </button>
   )
 }
 

--- a/web/src/components/layout/footer.tsx
+++ b/web/src/components/layout/footer.tsx
@@ -10,21 +10,23 @@ export default function Footer({ height }: { height: number }) {
   return (
     <footer
       style={{ height }}
-      className="w-full py-6 px-10 flex items-center justify-center text-sm text-gray-500 dark:text-gray-400 border-t border-gray-200 dark:border-gray-700"
+      className="w-full py-6 px-10 flex flex-col md:flex-row gap-1 md:gap-0 items-center justify-center text-center text-sm text-gray-500 dark:text-gray-400 border-t border-gray-200 dark:border-gray-700"
     >
-      ©
-      {' '}
-      {new Date().getFullYear()}
-      {' '}
-      {siteInfo?.metadata?.name}
-      {' '}
-      · Powered by
-      {' '}
-      <Link href="https://github.com/snowykami/neo-blog" target="_blank" className="underline hover:text-gray-700 dark:hover:text-gray-300 mx-1">Neo Blog</Link>
-      {' '}
-      ·
-      {' '}
-      {siteInfo?.footer?.text}
+      <span>
+        ©
+        {' '}
+        {new Date().getFullYear()}
+        {' '}
+        {siteInfo?.metadata?.name}
+      </span>
+      <span className="hidden md:inline mx-1">·</span>
+      <span>
+        Powered by
+        {' '}
+        <Link href="https://github.com/snowykami/neo-blog" target="_blank" className="underline hover:text-gray-700 dark:hover:text-gray-300">Neo Blog</Link>
+      </span>
+      <span className="hidden md:inline mx-1">·</span>
+      <span>{siteInfo?.footer?.text}</span>
     </footer>
   )
 }

--- a/web/src/contexts/music-context.tsx
+++ b/web/src/contexts/music-context.tsx
@@ -1,7 +1,7 @@
 'use client'
 import type { MusicLyrics } from '@/api/music'
 import type { MusicTrack } from '@/models/music'
-import type { MusicLyricItem, MusicLyricLine } from '@/utils/music-lyric'
+import type { MusicLyricItem, MusicLyricLine, MusicLyricMode } from '@/utils/music-lyric'
 import React, {
   createContext,
   useCallback,
@@ -26,13 +26,21 @@ interface MusicContextValue {
   duration: number | null
   bufferedPercent: number
   rotateDeg: number // 专辑封面旋转角度（用于动画）
+  volume: number
+  isMuted: boolean
   currentLyric: string | null
   currentLyricIndex: number | null
   currentLyricWords: MusicLyricItem[]
   currentWordIndex: number | null
   lyricLines: { time: number, text: string }[]
   parsedLyricLines: MusicLyricLine[]
+  translationLyricLines: MusicLyricLine[]
+  romajiLyricLines: MusicLyricLine[]
   lyricSourceType: 'yrc' | 'lrc' | 'none'
+  lyricMode: MusicLyricMode
+  setLyricMode: (mode: MusicLyricMode) => void
+  hasTranslationLyric: boolean
+  hasRomajiLyric: boolean
   getAudio: () => HTMLAudioElement | null
 
   // 播放列表 操作
@@ -51,6 +59,7 @@ interface MusicContextValue {
   // 可选：音量/进度控制
   seek: (seconds: number) => void // 跳转到指定秒数
   setVolume: (v: number) => void // 设置音量 0~1
+  toggleMuted: () => void // 切换静音
 
   // sample track 样品曲目，用于在未获取到时fallback
   sampleTrack: MusicTrack
@@ -77,15 +86,55 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const [duration, setDuration] = useState<number | null>(null)
   const [bufferedPercent, setBufferedPercent] = useState<number>(0)
   const [rotateDeg, setRotateDeg] = useState(0)
+  const [volume, setVolumeState] = useState(1)
+  const [isMuted, setIsMuted] = useState(false)
   const [lyrics, setLyrics] = useState<MusicLyrics | null>(null) // 原始歌词响应
   const [currentLyric, setCurrentLyric] = useState<string | null>(null) // 当前歌词行文本
   const [currentLyricIndex, setCurrentLyricIndex] = useState<number | null>(null) // 当前歌词行索引
   const [currentWordIndex, setCurrentWordIndex] = useState<number | null>(null) // 当前歌词字索引
   const [lyricLines, setLyricLines] = useState<{ time: number, text: string }[]>([]) // 解析后的歌词行列表
   const [parsedLyricLines, setParsedLyricLines] = useState<MusicLyricLine[]>([]) // 解析后的逐字歌词行
+  const [translationLyricLines, setTranslationLyricLines] = useState<MusicLyricLine[]>([])
+  const [romajiLyricLines, setRomajiLyricLines] = useState<MusicLyricLine[]>([])
+  const [lyricMode, setLyricModeState] = useState<MusicLyricMode>('translation')
   const [lyricSourceType, setLyricSourceType] = useState<'yrc' | 'lrc' | 'none'>('none')
   const currentTrack = currentIndex != null ? playlist[currentIndex] ?? null : null
   const getAudio = useCallback(() => audioRef.current, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined')
+      return
+
+    try {
+      const storedVolume = localStorage.getItem('music-volume')
+      if (storedVolume != null) {
+        const nextVolume = Math.max(0, Math.min(1, Number(JSON.parse(storedVolume))))
+        if (Number.isFinite(nextVolume)) {
+          setVolumeState(nextVolume)
+          if (audioRef.current)
+            audioRef.current.volume = nextVolume
+        }
+      }
+
+      const storedMuted = localStorage.getItem('music-muted')
+      if (storedMuted != null) {
+        const nextMuted = Boolean(JSON.parse(storedMuted))
+        setIsMuted(nextMuted)
+        if (audioRef.current)
+          audioRef.current.muted = nextMuted
+      }
+
+      const storedLyricMode = localStorage.getItem('music-lyric-mode')
+      if (storedLyricMode != null) {
+        const nextLyricMode = JSON.parse(storedLyricMode)
+        if (nextLyricMode === 'none' || nextLyricMode === 'romaji' || nextLyricMode === 'translation')
+          setLyricModeState(nextLyricMode)
+      }
+    }
+    catch (error) {
+      console.error('Failed to restore music preferences:', error)
+    }
+  }, [])
   // 旋转动画
   useEffect(() => {
     let rafId: number | null = null
@@ -110,9 +159,18 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     if (!audioRef.current) {
       const audio = new Audio()
       audio.preload = 'metadata'
+      audio.volume = volume
+      audio.muted = isMuted
       audioRef.current = audio
     }
-  }, [])
+  }, [isMuted, volume])
+
+  useEffect(() => {
+    if (!audioRef.current)
+      return
+    audioRef.current.volume = volume
+    audioRef.current.muted = isMuted
+  }, [isMuted, volume])
 
   // 当 currentTrack 变化时更新 audio.src和歌词（仅在 track id 变化时），并在 pendingPlay 时尝试播放
   useEffect(() => {
@@ -271,6 +329,8 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     if (!lyrics) {
       setLyricLines([])
       setParsedLyricLines([])
+      setTranslationLyricLines([])
+      setRomajiLyricLines([])
       setLyricSourceType('none')
       setCurrentLyric(null)
       setCurrentLyricIndex(null)
@@ -285,12 +345,16 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         text: line.originalText,
       }))
       setParsedLyricLines(parsed.lines)
+      setTranslationLyricLines(parsed.translationLines)
+      setRomajiLyricLines(parsed.romajiLines)
       setLyricSourceType(parsed.sourceType)
       setLyricLines(mapped)
     }
     catch (error) {
       console.error('Failed to parse lyrics:', error)
       setParsedLyricLines([])
+      setTranslationLyricLines([])
+      setRomajiLyricLines([])
       setLyricSourceType('none')
       setLyricLines([])
     }
@@ -406,9 +470,35 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   const setVolume = useCallback((v: number) => {
     const audio = audioRef.current
-    if (!audio)
-      return
-    audio.volume = Math.max(0, Math.min(1, v))
+    const nextVolume = Math.max(0, Math.min(1, v))
+    setVolumeState(nextVolume)
+    if (audio)
+      audio.volume = nextVolume
+    try {
+      localStorage.setItem('music-volume', JSON.stringify(nextVolume))
+    }
+    catch { }
+  }, [])
+
+  const toggleMuted = useCallback(() => {
+    setIsMuted((prev) => {
+      const nextMuted = !prev
+      if (audioRef.current)
+        audioRef.current.muted = nextMuted
+      try {
+        localStorage.setItem('music-muted', JSON.stringify(nextMuted))
+      }
+      catch { }
+      return nextMuted
+    })
+  }, [])
+
+  const setLyricMode = useCallback((mode: MusicLyricMode) => {
+    setLyricModeState(mode)
+    try {
+      localStorage.setItem('music-lyric-mode', JSON.stringify(mode))
+    }
+    catch { }
   }, [])
 
   const sampleTrack: MusicTrack = {
@@ -537,13 +627,21 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     duration,
     bufferedPercent,
     rotateDeg,
+    volume,
+    isMuted,
     currentLyric,
     currentLyricIndex,
     currentLyricWords: currentLyricIndex == null ? [] : parsedLyricLines[currentLyricIndex]?.items ?? [],
     currentWordIndex,
     lyricLines,
     parsedLyricLines,
+    translationLyricLines,
+    romajiLyricLines,
     lyricSourceType,
+    lyricMode,
+    setLyricMode,
+    hasTranslationLyric: translationLyricLines.length > 0,
+    hasRomajiLyric: romajiLyricLines.length > 0,
     getAudio,
     replacePlaylist,
     playTrack,
@@ -556,6 +654,7 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setCurrentIndex,
     seek,
     setVolume,
+    toggleMuted,
     sampleTrack,
   }
 

--- a/web/src/utils/music-lyric.ts
+++ b/web/src/utils/music-lyric.ts
@@ -1,4 +1,5 @@
 import type { MusicLyrics } from '@/api/music'
+import { isKana, isRomaji, toRomaji } from 'wanakana'
 
 export interface MusicLyricItem {
   text: string
@@ -16,7 +17,24 @@ export interface MusicLyricLine {
 export interface MusicLyricParseResult {
   sourceType: 'yrc' | 'lrc' | 'none'
   lines: MusicLyricLine[]
+  translationLines: MusicLyricLine[]
+  romajiLines: MusicLyricLine[]
 }
+
+export type MusicLyricMode = 'none' | 'romaji' | 'translation'
+
+interface TimedRomajiUnit {
+  text: string
+  reading: string
+  startTime: number
+  duration: number
+}
+
+const JAPANESE_PUNCTUATION_RE = /^[\s、。，．・･！？!?…♪「」『』（）()[\]【】〈〉《》“”"'‘’—~〜-]+$/
+const SMALL_KANA_RE = /^[ゃゅょャュョぁぃぅぇぉァィゥェォゎヮヶヵ]$/
+const ATTACH_TO_PREVIOUS_RE = /^[ーｰ〜~]$/
+const ATTACH_TO_NEXT_RE = /^[っッ]$/
+const LATIN_OR_NUMBER_RE = /[a-z0-9]/i
 
 function parseLrc(lrcText: string): MusicLyricLine[] {
   const lines: MusicLyricLine[] = []
@@ -28,19 +46,26 @@ function parseLrc(lrcText: string): MusicLyricLine[] {
     const startTime = (Number.parseInt(minutes, 10) * 60 + Number.parseInt(seconds, 10)) * 1000 + Number.parseInt(ms.padEnd(3, '0').slice(0, 3), 10)
     const trimmedText = text.trim()
 
-    if (!trimmedText)
-      continue
-
-    lines.push({
-      items: [{ text: trimmedText, startTime, duration: 0 }],
-      startTime,
-      duration: 0,
-      originalText: trimmedText,
-    })
+    if (trimmedText) {
+      lines.push({
+        items: [{ text: trimmedText, startTime, duration: 0 }],
+        startTime,
+        duration: 0,
+        originalText: trimmedText,
+      })
+    }
     match = lineRegex.exec(lrcText)
   }
 
   return lines.sort((a, b) => a.startTime - b.startTime)
+}
+
+function sanitizeExtraLyricLines(lines: MusicLyricLine[]): MusicLyricLine[] {
+  return lines.map(line => ({
+    ...line,
+    items: line.items.map(item => ({ ...item, text: item.text.replace(/〖|〗/g, '').trim() })),
+    originalText: line.originalText.replace(/〖|〗/g, '').trim(),
+  })).filter(line => line.originalText)
 }
 
 function parseYrcLine(lineText: string): MusicLyricLine | null {
@@ -92,22 +117,264 @@ function parseYrc(yrcText: string): MusicLyricLine[] {
     .sort((a, b) => a.startTime - b.startTime)
 }
 
+function parseExtraLyric(lyricText: string | undefined): MusicLyricLine[] {
+  if (!lyricText)
+    return []
+
+  const trimmedText = lyricText.trim()
+  const parsedLines = /^\[\d+,\d+\]/m.test(trimmedText)
+    ? parseYrc(trimmedText)
+    : parseLrc(trimmedText)
+
+  return sanitizeExtraLyricLines(parsedLines)
+}
+
+function splitRomajiText(text: string): string[] {
+  const tokens = text.trim().split(/\s+/).filter(Boolean)
+  return tokens.map((token, index) => index < tokens.length - 1 ? `${token} ` : token)
+}
+
+function normalizeRomajiText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '')
+}
+
+function getItemReading(text: string): string {
+  if (isRomaji(text))
+    return normalizeRomajiText(text)
+  if (isKana(text))
+    return normalizeRomajiText(toRomaji(text))
+  return normalizeRomajiText(text)
+}
+
+function getItemEndTime(item: MusicLyricItem): number {
+  return item.startTime + item.duration
+}
+
+function createTimedUnit(items: MusicLyricItem[]): TimedRomajiUnit | null {
+  if (items.length === 0)
+    return null
+
+  const startTime = items[0].startTime
+  const endTime = items.reduce((end, item) => Math.max(end, getItemEndTime(item)), startTime)
+  const text = items.map(item => item.text).join('')
+
+  return {
+    text,
+    reading: getItemReading(text),
+    startTime,
+    duration: Math.max(0, endTime - startTime),
+  }
+}
+
+function createTimedRomajiUnits(baseLine: MusicLyricLine): TimedRomajiUnit[] {
+  const units: TimedRomajiUnit[] = []
+  let pending: MusicLyricItem[] = []
+  let attachNext: MusicLyricItem[] = []
+
+  const flush = () => {
+    const unit = createTimedUnit(pending)
+    if (unit)
+      units.push(unit)
+    pending = []
+  }
+
+  for (const item of baseLine.items) {
+    const text = item.text.trim()
+    if (!text || JAPANESE_PUNCTUATION_RE.test(text))
+      continue
+
+    if (ATTACH_TO_NEXT_RE.test(text)) {
+      attachNext.push(item)
+      continue
+    }
+
+    if (ATTACH_TO_PREVIOUS_RE.test(text) || SMALL_KANA_RE.test(text)) {
+      pending.push(item)
+      continue
+    }
+
+    flush()
+    pending = [...attachNext, item]
+    attachNext = []
+
+    if (LATIN_OR_NUMBER_RE.test(text))
+      flush()
+  }
+
+  if (attachNext.length > 0)
+    pending.push(...attachNext)
+  flush()
+
+  return units
+}
+
+function splitRomajiTokenParts(tokens: string[]): string[] {
+  return tokens.flatMap((token) => {
+    const trailingSpace = token.match(/\s+$/)?.[0] ?? ''
+    const trimmedToken = token.trim()
+    if (!trimmedToken)
+      return []
+
+    const parts = trimmedToken.match(/[a-z0-9]+|[^a-z0-9\s]+/gi) ?? [trimmedToken]
+    return parts.map((part, index) => index === parts.length - 1 ? `${part}${trailingSpace}` : part)
+  })
+}
+
+function buildUnitBasedRomajiItems(baseLine: MusicLyricLine, tokens: string[]): MusicLyricItem[] | null {
+  const units = createTimedRomajiUnits(baseLine)
+  if (units.length === 0)
+    return null
+
+  const tokenParts = splitRomajiTokenParts(tokens)
+  if (tokenParts.length === 0)
+    return null
+
+  const items: MusicLyricItem[] = []
+  let unitIndex = 0
+  let tokenIndex = 0
+
+  while (unitIndex < units.length && tokenIndex < tokenParts.length) {
+    const unit = units[unitIndex]
+    const token = tokenParts[tokenIndex]
+    const normalizedToken = normalizeRomajiText(token)
+
+    if (!normalizedToken) {
+      tokenIndex += 1
+      continue
+    }
+
+    if (unit.reading && normalizedToken === unit.reading) {
+      items.push({ text: token, startTime: unit.startTime, duration: unit.duration })
+      unitIndex += 1
+      tokenIndex += 1
+      continue
+    }
+
+    if (unit.reading && normalizedToken.startsWith(unit.reading)) {
+      items.push({ text: token, startTime: unit.startTime, duration: unit.duration })
+      unitIndex += 1
+      tokenIndex += 1
+      continue
+    }
+
+    if (unit.reading && unit.reading.startsWith(normalizedToken)) {
+      const groupStart = unitIndex
+      let groupedReading = ''
+      while (unitIndex < units.length && groupedReading.length < normalizedToken.length) {
+        groupedReading += units[unitIndex].reading
+        unitIndex += 1
+      }
+      const groupUnits = units.slice(groupStart, unitIndex)
+      const startTime = groupUnits[0].startTime
+      const endTime = groupUnits.reduce((end, currentUnit) => Math.max(end, currentUnit.startTime + currentUnit.duration), startTime)
+      items.push({ text: token, startTime, duration: Math.max(0, endTime - startTime) })
+      tokenIndex += 1
+      continue
+    }
+
+    return null
+  }
+
+  if (tokenIndex !== tokenParts.length)
+    return null
+
+  return items
+}
+
+function buildEvenRomajiItems(baseLine: MusicLyricLine, tokens: string[], timedBaseItems: MusicLyricItem[]): MusicLyricItem[] {
+  const lineDuration = baseLine.duration > 0
+    ? baseLine.duration
+    : timedBaseItems[timedBaseItems.length - 1].startTime + timedBaseItems[timedBaseItems.length - 1].duration - baseLine.startTime
+  const tokenDuration = lineDuration / tokens.length
+  return tokens.map((token, index) => ({
+    text: token,
+    startTime: Math.round(baseLine.startTime + tokenDuration * index),
+    duration: Math.max(0, Math.round(tokenDuration)),
+  }))
+}
+
+function inferTimedExtraLine(baseLine: MusicLyricLine, extraLine: MusicLyricLine): MusicLyricLine {
+  if (extraLine.items.some(item => item.duration > 0))
+    return extraLine
+
+  const tokens = splitRomajiText(extraLine.originalText)
+  const timedBaseItems = baseLine.items.filter(item => item.duration > 0)
+
+  if (tokens.length === 0 || timedBaseItems.length === 0)
+    return extraLine
+
+  const unitBasedItems = buildUnitBasedRomajiItems(baseLine, tokens)
+  if (unitBasedItems) {
+    return {
+      items: unitBasedItems,
+      startTime: baseLine.startTime,
+      duration: baseLine.duration,
+      originalText: extraLine.originalText,
+    }
+  }
+
+  if (tokens.length > timedBaseItems.length) {
+    return {
+      items: buildEvenRomajiItems(baseLine, tokens, timedBaseItems),
+      startTime: baseLine.startTime,
+      duration: baseLine.duration,
+      originalText: extraLine.originalText,
+    }
+  }
+
+  const inferredItems = tokens.map((token, index) => {
+    const startIndex = Math.floor(index * timedBaseItems.length / tokens.length)
+    const endIndex = Math.max(startIndex, Math.floor((index + 1) * timedBaseItems.length / tokens.length) - 1)
+    const startItem = timedBaseItems[startIndex]
+    const endItem = timedBaseItems[endIndex]
+    const startTime = startItem.startTime
+    const endTime = endItem.startTime + endItem.duration
+
+    return {
+      text: token,
+      startTime,
+      duration: Math.max(0, endTime - startTime),
+    }
+  })
+
+  return {
+    items: inferredItems,
+    startTime: baseLine.startTime,
+    duration: baseLine.duration,
+    originalText: extraLine.originalText,
+  }
+}
+
+function inferTimedExtraLines(baseLines: MusicLyricLine[], extraLines: MusicLyricLine[]): MusicLyricLine[] {
+  if (baseLines.length === 0 || extraLines.length === 0)
+    return extraLines
+
+  return baseLines.map((baseLine) => {
+    const extraLine = getExtraLyricLine(extraLines, baseLine.startTime)
+    return extraLine ? inferTimedExtraLine(baseLine, extraLine) : null
+  }).filter((line): line is MusicLyricLine => Boolean(line))
+}
+
 export function parseMusicLyrics(rawLyric: MusicLyrics | null): MusicLyricParseResult {
+  const translationLines = parseExtraLyric(rawLyric?.ytlrc?.lyric?.trim() || rawLyric?.tlyric?.lyric?.trim())
+  const romajiLines = parseExtraLyric(rawLyric?.yromalrc?.lyric?.trim() || rawLyric?.romalrc?.lyric?.trim())
   const yrcText = rawLyric?.yrc?.lyric?.trim()
   if (yrcText) {
     const lines = parseYrc(yrcText)
     if (lines.length > 0)
-      return { sourceType: 'yrc', lines }
+      return { sourceType: 'yrc', lines, translationLines, romajiLines: inferTimedExtraLines(lines, romajiLines) }
   }
 
   const lrcText = rawLyric?.lrc?.lyric?.trim()
   if (lrcText) {
     const lines = parseLrc(lrcText)
     if (lines.length > 0)
-      return { sourceType: 'lrc', lines }
+      return { sourceType: 'lrc', lines, translationLines, romajiLines }
   }
 
-  return { sourceType: 'none', lines: [] }
+  return { sourceType: 'none', lines: [], translationLines, romajiLines }
 }
 
 export function getCurrentLyricIndex(lines: MusicLyricLine[], currentTimeMs: number, previousIndex: number | null): number | null {
@@ -162,4 +429,23 @@ export function getWordProgress(item: MusicLyricItem, currentTimeMs: number): nu
     return currentTimeMs >= item.startTime ? 1 : 0
 
   return Math.max(0, Math.min(1, (currentTimeMs - item.startTime) / item.duration))
+}
+
+export function getExtraLyricText(lines: MusicLyricLine[], lineStartTime: number): string {
+  return getExtraLyricLine(lines, lineStartTime)?.originalText ?? ''
+}
+
+export function getExtraLyricLine(lines: MusicLyricLine[], lineStartTime: number): MusicLyricLine | null {
+  if (lines.length === 0)
+    return null
+
+  const exactLine = lines.find(line => line.startTime === lineStartTime)
+  if (exactLine)
+    return exactLine
+
+  const closestLine = lines.reduce((prev, curr) =>
+    Math.abs(curr.startTime - lineStartTime) < Math.abs(prev.startTime - lineStartTime) ? curr : prev,
+  )
+
+  return closestLine
 }


### PR DESCRIPTION
## Summary
- Add wanakana-backed foreign lyric and romaji support for word-level lyrics
- - Smooth the lyric sweep in the player popup and title context
- - Persist player preferences such as volume, mute state, and lyric mode
- - Adjust the mobile footer layout to three vertical rows
## Validation
- cd web && pnpm lint
- - cd web && pnpm exec tsc --noEmit --pretty false
- - docker build -f web/Dockerfile web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mute button to the music player
  * Added lyric mode switching to cycle between romaji and translation displays
  * Added time-synchronized display of translated and romaji lyrics
  * Volume and mute settings now persist across sessions

* **Style**
  * Improved footer layout for better responsive design

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snowykami/neo-blog/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->